### PR TITLE
WIP: pull mne dev version, no pysurfer

### DIFF
--- a/180309_marburg/Dockerfile
+++ b/180309_marburg/Dockerfile
@@ -80,13 +80,12 @@ RUN conda create -y -q --name py27 python=2.7 \
 RUN bash -c "source activate neuro \
     && conda install -y -q jupyter \
                            matplotlib \
-                           mayavi \
                            scikit-learn \
                            scipy \
-                           spyder \
+                           pandas \
     && conda clean -tipsy \
-    && pip install -q --no-cache-dir mne \
-                                     PySurfer"
+    && pip install -q --no-cache-dir \
+        git+git://github.com/mne-tools/mne-python.git@10b9ab9ef352a5f2fca4e786046b3c7ca7cf1098"
 
 USER root
 


### PR DESCRIPTION
Do not merge, a post-midnight PR probably isn't a good PR.

Thoughts:
Why spyder?

If Mayavi only for MNE: don't need it.

Could also directly pull master ...
`pip install -q --no-cache-dir https://codeload.github.com/mne-tools/mne-python/zip/master`